### PR TITLE
Implement tokio timer API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ tokio-reactor = "0.1"
 mio = "0.6"
 timerfd = "1.0"
 futures = "0.1"
+slab = "0.4"
 
 [dev-dependencies]
 tokio = "0.1"

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,0 +1,103 @@
+use crate::{ClockId, TimerFd};
+use futures::{try_ready, Async, Future, task};
+use std::io::Error as IoError;
+use std::time::Instant;
+use timerfd::{SetTimeFlags, TimerState};
+
+/// A future that completes at a specified instant in time.
+/// Instances of Delay perform no work and complete with () once the specified deadline has been reached.
+/// Delays is powered by `timerfd` and has a resolution of 1 nanosecond.
+pub struct Delay {
+    timerfd: TimerFd,
+    deadline: Instant,
+    initialized: bool,
+    task: Option<task::Task>,
+}
+
+impl Delay {
+    pub fn new(deadline: Instant) -> Result<Self, IoError> {
+        let timerfd = TimerFd::new(ClockId::Monotonic)?;
+        Ok(Delay {
+            timerfd,
+            deadline,
+            initialized: false,
+            task: None,
+        })
+    }
+
+    pub fn deadline(&self) -> Instant {
+        self.deadline
+    }
+
+    pub fn is_elapsed(&self) -> bool {
+        self.deadline > Instant::now()
+    }
+
+    pub fn reset(&mut self, deadline: Instant) {
+        self.deadline = deadline;
+        self.initialized = false;
+        if let Some(task) = &self.task {
+            task.notify()
+        }
+    }
+}
+
+impl Future for Delay {
+    type Item = ();
+    type Error = IoError;
+
+    fn poll(&mut self) -> Result<Async<Self::Item>, Self::Error> {
+        if !self.initialized {
+            let now = Instant::now();
+            let duration = if self.deadline > now {
+                self.deadline - now
+            } else {
+                return Ok(Async::Ready(()));
+            };
+            self.timerfd
+                .set_state(TimerState::Oneshot(duration), SetTimeFlags::Default);
+            self.initialized = true;
+        }
+        try_ready!(self.timerfd.poll_read());
+        Ok(Async::Ready(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+    use tokio::prelude::*;
+
+    #[test]
+    fn delay_zero_duration() {
+        tokio::run(future::lazy(|| {
+            let now = Instant::now();
+            let delay = Delay::new(Instant::now());
+            delay
+                .and_then(|_| {
+                    let elapsed = now.elapsed();
+                    println!("{:?}", elapsed);
+                    assert!(elapsed < Duration::from_millis(1));
+                    Ok(())
+                })
+                .map_err(|err| panic!("{:?}", err))
+        }));
+    }
+
+    #[test]
+    fn delay_works() {
+        tokio::run(future::lazy(|| {
+            let now = Instant::now();
+            let delay = Delay::new(now + Duration::from_micros(10));
+            delay
+                .and_then(|_| {
+                    let elapsed = now.elapsed();
+                    println!("{:?}", elapsed);
+                    assert!(elapsed < Duration::from_millis(1));
+                    Ok(())
+                })
+                .map_err(|err| panic!("{:?}", err))
+        }));
+    }
+}

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,5 +1,5 @@
 use crate::{ClockId, TimerFd};
-use futures::{try_ready, Async, Future, task};
+use futures::{task, try_ready, Async, Future};
 use std::io::Error as IoError;
 use std::time::Instant;
 use timerfd::{SetTimeFlags, TimerState};

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -94,15 +94,19 @@ mod tests {
         tokio::run(future::lazy(|| {
             let now = Instant::now();
             let mut delay_fired = false;
-            let delay = Delay::new(now + Duration::from_millis(500)).unwrap().and_then(move |_| {
-                delay_fired = true;
-                Ok(())
-            });
-            delay.select(future::ok(())).and_then(move |_| {
-                assert_eq!(delay_fired, false);
-                Ok(())
-            })
-            .map_err(|_err| panic!())
+            let delay = Delay::new(now + Duration::from_millis(500))
+                .unwrap()
+                .and_then(move |_| {
+                    delay_fired = true;
+                    Ok(())
+                });
+            delay
+                .select(future::ok(()))
+                .and_then(move |_| {
+                    assert_eq!(delay_fired, false);
+                    Ok(())
+                })
+                .map_err(|_err| panic!())
         }))
     }
 

--- a/src/delay_queue.rs
+++ b/src/delay_queue.rs
@@ -1,0 +1,148 @@
+use crate::{ClockId, TimerFd};
+use futures::{try_ready, Async, Stream, task};
+use slab::Slab;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::io::Error as IoError;
+use std::time::{Duration, Instant};
+use timerfd::{SetTimeFlags, TimerState};
+
+struct Entry {
+    expiration: Instant,
+    index: usize,
+}
+
+impl PartialOrd for Entry {
+    fn partial_cmp(&self, other: &Entry) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for Entry {
+    fn cmp(&self, other: &Entry) -> std::cmp::Ordering {
+        self.expiration.cmp(&other.expiration)
+    }
+}
+impl PartialEq for Entry {
+    fn eq(&self, other: &Entry) -> bool {
+        self.cmp(other) == std::cmp::Ordering::Equal
+    }
+}
+impl Eq for Entry {}
+
+#[derive(Debug)]
+pub struct Key(usize);
+
+pub struct DelayQueue<T> {
+    timerfd: TimerFd,
+    slab: Slab<T>,
+    heap: BinaryHeap<Reverse<Entry>>,
+    task: Option<task::Task>,
+}
+
+impl<T> DelayQueue<T> {
+    pub fn new() -> Result<DelayQueue<T>, IoError> {
+        let timerfd = TimerFd::new(ClockId::Monotonic)?;
+        Ok(DelayQueue {
+            timerfd,
+            heap: BinaryHeap::new(),
+            slab: Slab::new(),
+            task: None,
+        })
+    }
+
+    fn poll_next(&mut self) -> Result<Async<Option<Expired<T>>>, IoError> {
+        let now = Instant::now();
+        if let Some(item) = self.heap.peek() {
+            if item.0.expiration > now {
+                let duration = item.0.expiration - now;
+                self.timerfd
+                    .set_state(TimerState::Oneshot(duration), SetTimeFlags::Default);
+            } else {
+                let item = self.heap.pop().unwrap();
+                let data = self.slab.remove(item.0.index);
+
+                if let Some(task) = &self.task {
+                    task.notify();
+                }
+
+                return Ok(Async::Ready(Some(Expired {
+                    data,
+                    deadline: item.0.expiration,
+                    key: Key(item.0.index),
+                })))
+            };
+        }
+        Ok(Async::NotReady)
+    }
+
+    pub fn insert_at(&mut self, value: T, when: Instant) -> Key {
+        let idx = self.slab.insert(value);
+        self.heap.push(Reverse(Entry {
+            expiration: when,
+            index: idx,
+        }));
+        if let Some(task) = &self.task {
+            task.notify();
+        }
+        Key(idx)
+    }
+
+    pub fn insert(&mut self, value: T, timeout: Duration) -> Key {
+        self.insert_at(value, Instant::now() + timeout)
+    }
+
+    pub fn clear(&mut self) {
+        self.heap.clear();
+        self.slab.clear();
+    }
+}
+
+#[derive(Debug)]
+pub struct Expired<T> {
+    data: T,
+    deadline: Instant,
+    key: Key,
+}
+
+impl<T> Expired<T> {
+    pub fn into_inner(self) -> T {
+        self.data
+    }
+}
+
+impl<T> Stream for DelayQueue<T> {
+    type Item = Expired<T>;
+    type Error = IoError;
+
+    fn poll(&mut self) -> Result<Async<Option<Self::Item>>, Self::Error> {
+        self.timerfd.poll_read()?;
+        self.task = Some(task::current());
+        let expired = try_ready!(self.poll_next());
+        Ok(Async::Ready(expired))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Instant, Duration};
+    use tokio::prelude::*;
+
+    #[test]
+    fn delay_queue_works() {
+        tokio::run(future::lazy(|| {
+            let now = Instant::now();
+            let mut queue = DelayQueue::new().unwrap();
+            queue.insert_at(3u32, now + Duration::from_micros(30));
+            queue.insert_at(1u32, now + Duration::from_micros(10));
+            queue.insert_at(4u32, now + Duration::from_micros(40));
+            queue.insert_at(2u32, now + Duration::from_micros(20));
+            let mut ctr = 1;
+            queue.take(4).for_each(move |item| {
+                assert_eq!(item.into_inner(), ctr);
+                ctr += 1;
+                Ok(())
+            }).map_err(|_| ())
+        }))
+    }
+}

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -1,0 +1,103 @@
+use crate::{ClockId, TimerFd};
+use futures::{try_ready, Async, Stream};
+use std::io::Error as IoError;
+use std::time::{Duration, Instant};
+use timerfd::{SetTimeFlags, TimerState};
+
+pub struct Interval {
+    timerfd: TimerFd,
+    at: Instant,
+    duration: Duration,
+    initialized: bool,
+}
+
+impl Interval {
+    pub fn new(at: Instant, duration: Duration) -> Result<Interval, IoError> {
+        let timerfd = TimerFd::new(ClockId::Monotonic)?;
+        Ok(Interval {
+            timerfd,
+            at,
+            duration,
+            initialized: false,
+        })
+    }
+
+    pub fn new_interval(duration: Duration) -> Result<Interval, IoError> {
+        Self::new(Instant::now() + duration, duration)
+    }
+}
+
+impl Stream for Interval {
+    type Item = ();
+    type Error = IoError;
+
+    fn poll(&mut self) -> Result<Async<Option<Self::Item>>, Self::Error> {
+        if !self.initialized {
+            let now = Instant::now();
+            let mut first_duration = if self.at > now {
+                self.at - now
+            } else {
+                self.duration
+            };
+            if first_duration == Duration::from_millis(0) {
+                first_duration = self.duration
+            }
+            if self.duration == Duration::from_millis(0) {
+                return Ok(Async::Ready(Some(())));
+            }
+            self.timerfd.set_state(
+                TimerState::Periodic {
+                    current: first_duration,
+                    interval: self.duration,
+                },
+                SetTimeFlags::Default,
+            );
+            self.initialized = true;
+        }
+        try_ready!(self.timerfd.poll_read());
+        Ok(Async::Ready(Some(())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+    use tokio::prelude::*;
+
+    #[test]
+    fn interval_works_zero() {
+        tokio::run(future::lazy(|| {
+            let now = Instant::now();
+            let interval = Interval::new(Instant::now(), Duration::from_micros(0)).unwrap();
+            interval
+                .take(2)
+                .map_err(|err| panic!("{:?}", err))
+                .for_each(move |_| Ok(()))
+                .and_then(move |_| {
+                    let elapsed = now.elapsed();
+                    println!("{:?}", elapsed);
+                    assert!(elapsed < Duration::from_millis(1));
+                    Ok(())
+                })
+        }));
+    }
+
+    #[test]
+    fn interval_works() {
+        tokio::run(future::lazy(|| {
+            let now = Instant::now();
+            let interval = Interval::new_interval(Duration::from_micros(1)).unwrap();
+            interval
+                .take(2)
+                .map_err(|err| panic!("{:?}", err))
+                .for_each(move |_| Ok(()))
+                .and_then(move |_| {
+                    let elapsed = now.elapsed();
+                    println!("{:?}", elapsed);
+                    assert!(elapsed < Duration::from_millis(1));
+                    Ok(())
+                })
+        }));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! This crates provides [tokio-timer](https://docs.rs/tokio-timer)-like API 
+//! This crates provides [tokio-timer](https://docs.rs/tokio-timer)-like API
 //! on top of timerfd. `timerfd` is a Linux-specific API providing timers as
 //! file descriptors. The advantage of `timerfd` is that it provides more
 //! granularity than epoll_wait, which only provides 1 millisecond timeouts.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,11 @@ impl TimerFd {
     }
 }
 
+/// Create a Future that completes in `duration` from now.
+pub fn sleep(duration: Duration) -> Delay {
+    Delay::new(Instant::now() + duration)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,14 @@ use tokio_reactor::PollEvented;
 
 pub use timerfd::ClockId;
 
+mod delay;
+mod delay_queue;
+mod interval;
+
+pub use delay::Delay;
+pub use delay_queue::DelayQueue;
+pub use interval::Interval;
+
 struct Inner(InnerTimerFd);
 
 impl Evented for Inner {
@@ -34,8 +42,20 @@ impl TimerFd {
         Ok(TimerFd(inner))
     }
 
+    fn set_state(&mut self, state: TimerState, flags: SetTimeFlags) {
+        (self.0).get_mut().0.set_state(state, flags);
+    }
+
+    fn poll_read(&mut self) -> Result<Async<()>> {
+        let ready = try_ready!(self.0.poll_read_ready(Ready::readable()));
+        self.0.get_mut().0.read();
+        self.0.clear_read_ready(ready)?;
+        Ok(Async::Ready(()))
+    }
+
+    #[deprecated(note = "please use Interval")]
     pub fn periodic(mut self, dur: Duration) -> impl Stream<Item = (), Error = std::io::Error> {
-        (self.0).get_mut().0.set_state(
+        self.set_state(
             TimerState::Periodic {
                 current: dur,
                 interval: dur,
@@ -43,9 +63,7 @@ impl TimerFd {
             SetTimeFlags::Default,
         );
         poll_fn(move || {
-            let ready = try_ready!(self.0.poll_read_ready(Ready::readable()));
-            self.0.get_mut().0.read();
-            self.0.clear_read_ready(ready)?;
+            try_ready!(self.poll_read());
             Ok(Async::Ready(Some(())))
         })
     }
@@ -66,9 +84,7 @@ mod tests {
                 .periodic(Duration::from_micros(1))
                 .take(2)
                 .map_err(|err| println!("{:?}", err))
-                .for_each(move |_| {
-                    Ok(())
-                })
+                .for_each(move |_| Ok(()))
                 .and_then(move |_| {
                     let elapsed = now.elapsed();
                     println!("{:?}", elapsed);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,13 @@
 //! This crates provides [tokio-timer](https://docs.rs/tokio-timer)-like API
-//! on top of timerfd. `timerfd` is a Linux-specific API providing timers as
-//! file descriptors. The advantage of `timerfd` is that it provides more
-//! granularity than epoll_wait, which only provides 1 millisecond timeouts.
+//! on top of timerfd. `timerfd` is a Linux-specific API providing timer notifications as
+//! file descriptor read events.
+//!
+//! The advantage of `timerfd` is that it has more granularity than epoll_wait(),
+//! which only provides 1 millisecond timeouts. `timerfd` API allows for nanosecond
+//! precision, but precise timing of the wakeup is not guaranteed on a normal
+//! multitasking system.
+//!
+//! Despite the name, this crate is *not* a part of the tokio project.
 //!
 //! * [`Delay`]: A future that completes at a specified instant in time.
 //! * [`Interval`] A stream that yields at fixed time intervals.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,24 @@
+//! This crates provides [tokio-timer](https://docs.rs/tokio-timer)-like API 
+//! on top of timerfd. `timerfd` is a Linux-specific API providing timers as
+//! file descriptors. The advantage of `timerfd` is that it provides more
+//! granularity than epoll_wait, which only provides 1 millisecond timeouts.
+//!
+//! * [`Delay`]: A future that completes at a specified instant in time.
+//! * [`Interval`] A stream that yields at fixed time intervals.
+//! * [`DelayQueue`]: A queue where items are returned once the requested delay
+//!   has expired.
+//!
+//! [`Delay`]: struct.Delay.html
+//! [`DelayQueue`]: struct.DelayQueue.html
+//! [`Interval`]: struct.Interval.html
+
 use futures::stream::poll_fn;
 use futures::{try_ready, Async, Stream};
 use mio::unix::EventedFd;
 use mio::{Evented, Poll, PollOpt, Ready, Token};
 use std::io::Result;
 use std::os::unix::io::AsRawFd;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use timerfd::{SetTimeFlags, TimerFd as InnerTimerFd, TimerState};
 use tokio_reactor::PollEvented;
 
@@ -71,7 +85,7 @@ impl TimerFd {
 
 /// Create a Future that completes in `duration` from now.
 pub fn sleep(duration: Duration) -> Delay {
-    Delay::new(Instant::now() + duration)
+    Delay::new(Instant::now() + duration).expect("can't create delay")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
 This is an incomplete reimplementation of tokio-timer API
 using timerfd.

 Differences:

  * lacks timeout APIs
  * new() returns Result, because we're doing io
  * DelayQueue is not a timer wheel
  * uses Instant::now(), not Clock
  * almost no tests
  * some methods are missing
  * no docs